### PR TITLE
Fix for #24417 - Unicode fix for snapshot history.

### DIFF
--- a/python/tk_multi_snapshot/snapshot_form.py
+++ b/python/tk_multi_snapshot/snapshot_form.py
@@ -11,6 +11,8 @@
 import tank
 from tank.platform.qt import QtCore, QtGui
 
+from .string_utils import safe_to_string
+
 thumbnail_widget = tank.platform.import_framework("tk-framework-widget", "thumbnail_widget")
 
 class ThumbnailWidget(thumbnail_widget.ThumbnailWidget):
@@ -73,7 +75,7 @@ class SnapshotForm(QtGui.QWidget):
     
     @property
     def comment(self):
-        return self._safe_to_string(self._ui.comment_edit.toPlainText()).rstrip()
+        return safe_to_string(self._ui.comment_edit.toPlainText()).rstrip()
         
     def show_result(self, status, msg):
         """
@@ -111,26 +113,5 @@ class SnapshotForm(QtGui.QWidget):
     def _on_show_history(self):
         self._exit_code = SnapshotForm.SHOW_HISTORY_RETURN_CODE
         self.close()
-        
-    def _safe_to_string(self, value):
-        """
-        safely convert the value to a string - handles
-        QtCore.QString if usign PyQt
-        """
-        #
-        if isinstance(value, basestring):
-            # it's a string anyway so just return
-            return value
-        
-        if hasattr(QtCore, "QString"):
-            # running PyQt!
-            if isinstance(value, QtCore.QString):
-                # QtCore.QString inherits from str but supports 
-                # unicode, go figure!  Lets play safe and return
-                # a utf-8 string
-                return str(value.toUtf8())
-        
-        # For everything else, just return as string
-        return str(value)
                 
     

--- a/python/tk_multi_snapshot/string_utils.py
+++ b/python/tk_multi_snapshot/string_utils.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2014 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from tank.platform.qt import QtCore
+
+def safe_to_string(value):
+    """
+    Safely convert the value to a string - handles
+    unicode and QtCore.QString if using PyQt
+    
+    :param value:    The value to convert to a string
+    :returns str:    utf8 encoded string of the input value
+    """
+    if isinstance(value, str):
+        # it's a string anyway so just return
+        return value
+    
+    if isinstance(value, unicode):
+        # convert to utf-8
+        return value.encode("utf8")
+
+    if hasattr(QtCore, "QString"):
+        # running PyQt!
+        if isinstance(value, QtCore.QString):
+            # QtCore.QString inherits from str but supports
+            # unicode, go figure!  Lets play safe and return
+            # a utf-8 string
+            return str(value.toUtf8())
+
+    # For everything else, just return as string
+    return str(value)


### PR DESCRIPTION
Snapshot history now handles unicode in the user name but not in the
comment!
