### PR TITLE
for #25713: manually emit kBeforeProjectLoad signal since hiero doesn't

### DIFF
--- a/hooks/scene_operation_tk-hiero.py
+++ b/hooks/scene_operation_tk-hiero.py
@@ -47,6 +47,9 @@ class SceneOperation(Hook):
             # first close the current project then open the specified file 
             project = self._get_current_project()
             project.close()
+            # manually fire signal since Hiero doesn't fire this when loading 
+            # from the tk file manager
+            hiero.core.events.sendEvent("kBeforeProjectLoad", None)
             hiero.core.openProject(file_path.replace(os.path.sep, "/"))
 
         elif operation == "save":


### PR DESCRIPTION
Hiero has a bunch of signals it emits when certain actions take place. This includes a signal emitted both before and after a project is loaded. When loading through Toolkit, Hiero doesn't emit the `kBeforeProjectLoad` signal (presumably because there's no way to know a project is about to be loaded when done this way?)

This emits the signal manually immediately prior to the opening of the project. All other signals are emitted as expected from Hiero.
