### PR TITLE
#46181 Uses better technique for retrieving the active doc and path

### DIFF
--- a/hooks/scene_operation_tk-photoshopcc.py
+++ b/hooks/scene_operation_tk-photoshopcc.py
@@ -37,16 +37,14 @@ class SceneOperation(Hook):
         """
         adobe = self.parent.engine.adobe
 
-        try:
-            doc = adobe.app.activeDocument
-        except RuntimeError:
+        doc = adobe.get_active_document()
+        if not doc:
             raise TankError("There is no active document!")
 
         if operation == "current_path":
             # return the current script path
-            try:
-                path = doc.fullName.fsName
-            except RuntimeError:
+            path = adobe.get_active_document_path()
+            if not path:
                 raise TankError("The active document must be saved!")
 
             return path


### PR DESCRIPTION
This updates the snapshot code to use the adobe bridge's method for retrieving the active document and path. The previous try/except was too specific with respect to the exception type. The new path will handle additional errors like AttributeError.

This is a continuation of the work done here: shotgunsoftware/tk-photoshopcc@d471b3a#diff-ec4ba2e3fd4512d2c469433269615506L355

and here: https://github.com/shotgunsoftware/tk-multi-publish/pull/40