### PR TITLE
Fix for nuke.scriptClear() crashing Nuke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# ---- ignore special files written during config setup
+tk-metadata
+
+# Byte-compiled / optimized / DLL files
 *.py[cod]
 
 # C extensions


### PR DESCRIPTION
Use an alternate "open in place" logic provided by the Foundry to work around `nuke.scriptClear()` crashing Nuke after submitting render to Deadline.

From Foundry support ticket 50513, Reference `46a9edc2-4f3c-4f4d-64ecca43-2a030103`