### PR TITLE
Prevent error on bootstrapping in a non-gui environment

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,14 @@ class MultiSnapshot(tank.platform.Application):
         """
         Called as the application is being initialized
         """
+        
+        # Ensure app isn't initialised in non-gui environments (eg a renderfarm)
+        if not self.engine.has_ui:
+            self.logger.debug(
+                "The engine reports that there is no UI. Snapshot will not continue initializing."
+            )
+            return
+
         self.tk_multi_snapshot = self.import_module("tk_multi_snapshot")
 
         # ensure snapshot template has at least one of increment or timestamp:


### PR DESCRIPTION
Snapshot will cause a bootstrap to error if run within a non-gui environment (eg hython).
Adding a check for a ui prevents this error.