### PR TITLE
SG-38694 Remove yaml deprecation warning

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -57,7 +57,7 @@ description: This app lets you quickly take a snapshot of the scene that you are
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.19.1"
+requires_core_version: "v0.20.30"
 requires_engine_version:
 
 # this app works in all engines - it does not contain any host application specific commands

--- a/python/tk_multi_snapshot/snapshot.py
+++ b/python/tk_multi_snapshot/snapshot.py
@@ -690,7 +690,7 @@ class Snapshot(object):
             comments = {}
             if os.path.exists(comments_file_path):
                 with open(comments_file_path, "r") as fp:
-                    raw_comments = yaml.load(fp) or {}
+                    raw_comments = yaml.load(fp, Loader=yaml.FullLoader) or {}
                     for (name, timestamp), comment in raw_comments.items():
                         fields["name"] = name
                         fields["timestamp"] = timestamp
@@ -738,7 +738,7 @@ class Snapshot(object):
         comments = {}
         if os.path.exists(comments_file_path):
             with open(comments_file_path, "r") as fp:
-                comments = yaml.load(fp) or {}
+                comments = yaml.load(fp, Loader=yaml.FullLoader) or {}
 
         # comment is now a dictionary so that we can also include the user:
         comments_value = {"comment": comment, "sg_user": self._app.context.user}
@@ -767,7 +767,7 @@ class Snapshot(object):
         raw_comments = {}
         if os.path.exists(comments_file_path):
             with open(comments_file_path, "r") as fp:
-                raw_comments = yaml.load(fp) or {}
+                raw_comments = yaml.load(fp, Loader=yaml.FullLoader) or {}
 
         # process raw comments to convert old-style to new if need to:
         for key, value in raw_comments.items():


### PR DESCRIPTION
Add `Loader=yaml.FullLoader` parameter to remove the following warning log:
```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```